### PR TITLE
Fix code block and reference

### DIFF
--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -106,8 +106,8 @@ font, R will try to load a different font. This can be done with
 
 Save yourself some aggrevation, and have everyone check and see if they can
 install all these packages before you start the first day.
-See the "Preparations" section on the homepage of the course website for
-package installation instructions.
+See the "Install required R packages" section on the homepage of the course
+website for package installation instructions.
 
 Sometimes learners are unable to install the **`tidyverse`** package.
 In that case, they can try to install the individual packages that are actually

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -89,7 +89,7 @@ During the course we will need a number of R packages. Packages contain useful R
 
 To try to install these packages, open RStudio and copy and paste the following command into the console window (look for a blinking cursor on the bottom left), then press the <kbd>Enter</kbd> (Windows and Linux) or <kbd>Return</kbd> (MacOS) to execute the command.
 
-```{r}
+```r
 install.packages(c("tidyverse", "lubridate", "ratdat"))
 ```
 


### PR DESCRIPTION
This pull request involves a fix of a fenced code block (from ` ```{r} ` to  ` ```r `) and an updated reference to the "Install required R packages" section on the homepage.