### PR TITLE
fct_explicit_na deprecated using fct_na_value_to_level instead

### DIFF
--- a/episodes/how-r-thinks-about-data.Rmd
+++ b/episodes/how-r-thinks-about-data.Rmd
@@ -381,7 +381,7 @@ fct_relevel(sex, c("male", "female"))
 fct_recode(sex, "M" = "male", "F" = "female")
 
 # turn NAs into an actual factor level (useful for including NAs in plots)
-fct_explicit_na(sex)
+fct_na_value_to_level(sex, "(Missing)")
 
 ```
 


### PR DESCRIPTION
Forcats 1.0.0 depreciated `fct_explicit_na`
Equivalent way is now `fct_na_value_to_level(sex, "(Missing)")`

Closes #11 


